### PR TITLE
Disable config usa_workspace_doc default

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
 					},
 					"protheusDoc.usa_workspace_doc": {
 						"type": "boolean",
-						"default": true,
+						"default": false,
 						"description": "Define se será adicionado todas as documentações da Workspace na tabela de documentações. Em caso de `false` somente os fontes que tiveram interação serão adicionados na tabela.",
 						"markdownDescription": "Define se será adicionado todas as documentações da Workspace na tabela de documentações. Em caso de `false` somente os fontes que tiveram interação serão adicionados na tabela."
 					},


### PR DESCRIPTION
- Altera o default da configuração `protheusDoc.usa_workspace_doc` para `false`, melhorando a experiência inicial da extensão, pois a lógica atual para varrer a workspace causa muita lentidão quando há uma quantidade grande de arquivos.
- Dessa forma a extensão por padrão não irá varrer toda a workspace em busca dos protheus doc, conforme documentado na wiki: [Tabela de Documentações](https://github.com/AlencarGabriel/ProtheusDoc-VsCode/wiki/Tabela-de-documenta%C3%A7%C3%B5es)
- Issues afetadas: 
  - AlencarGabriel/ProtheusDoc-VsCode#92
  - AlencarGabriel/ProtheusDoc-VsCode#77
  - AlencarGabriel/ProtheusDoc-VsCode#68
  - AlencarGabriel/ProtheusDoc-VsCode#67