### PR TITLE
Adicionando configuração para permitir inforar o datelocale

### DIFF
--- a/package.json
+++ b/package.json
@@ -289,6 +289,11 @@
 						"type": "number",
 						"default": 5120,
 						"description": "Máximo de arquivos para pesquisa da tabela de documentações."
+					},
+					"protheusDoc.dateLocale": {
+						"type": "string",
+						"default": "",
+						"markdownDescription": "Locale a ser usado na formatação de datas (ex.: pt-BR, en-US, ja-JP, de-DE). Vazio usa o locale do sistema."
 					}
 				}
 			}

--- a/src/objects/SyntaxAdvpl.ts
+++ b/src/objects/SyntaxAdvpl.ts
@@ -3,6 +3,7 @@ import { ISyntaxProtheusDoc, ETypesDoc, ETypesAdvpl } from '../interfaces/ISynta
 import { IParamsProtheusDoc } from '../interfaces/IParamsProtheusDoc';
 import * as fs from 'fs';
 import * as path from 'path';
+import { Utils } from '../objects/Utils';
 
 /**
  * Busca no Package JSON os exemplos de versões definidos para sugerir no atributo @version.
@@ -85,7 +86,9 @@ export class SyntaxAdvpl implements ISyntaxProtheusDoc {
     public getSince(date: Date | String): String {
 
         if (date instanceof Date) {
-            return "@since " + this.getTabStop(date.toLocaleDateString()) + "\n";
+            let util = new Utils();
+		    let locale = util.getDateLocale();
+            return "@since " + this.getTabStop(date.toLocaleDateString(locale)) + "\n";
         } else {
             return "@since " + this.getTabStop(date) + "\n";
         }

--- a/src/objects/Utils.ts
+++ b/src/objects/Utils.ts
@@ -210,4 +210,16 @@ export class Utils {
 			return 5120;
 		}
 	}
+
+	/**
+	 * Busca se foi definido um datelocale, que será utilizado na formatação da data do @Since
+	 */
+	public getDateLocale(): string | undefined {
+		let dateLocale: string | undefined = (this.getConfig().get<string>('dateLocale') || '').trim();
+
+		if (dateLocale === '') {
+			dateLocale = undefined;
+		}
+		return dateLocale
+	}
 }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -7,6 +7,7 @@ import { SyntaxAdvpl } from '../../objects/SyntaxAdvpl';
 import { ETypesDoc, ETypesAdvpl } from '../../interfaces/ISyntaxProtheusDoc';
 import { ProtheusDoc, ELanguageSupport } from '../../objects/ProtheusDoc';
 import { TransformAdvpl } from '../../objects/TransformAdvpl';
+import { Utils } from '../../objects/Utils';
 // import * as myExtension from '../extension';
 
 suite('Extension Test Suite', () => {
@@ -19,11 +20,13 @@ suite('Extension Test Suite', () => {
 
 	test('syntaxAdvpl', () => {
 		let syntax = new SyntaxAdvpl();
+		let util = new Utils();
+		let locale = util.getDateLocale();
 
 		assert.equal(syntax.getIdentifier("fTest"), "/*/{Protheus.doc} fTest\n\n");
 		assert.equal(syntax.getType(ETypesDoc.function), "@type function\n");
 		assert.equal(syntax.getAuthor("Gabriel Alencar"), "@author Gabriel Alencar\n");
-		assert.equal(syntax.getSince(new Date()), "@since " + new Date().toLocaleDateString() + "\n");
+		assert.equal(syntax.getSince(new Date()), "@since " + new Date().toLocaleDateString(locale) + "\n");
 		assert.equal(syntax.getVersion("12.1.17"), "@version 12.1.17\n");
 		assert.equal(syntax.getParams([{ paramName: "cName", paramType: ETypesAdvpl.C, paramDescription: "Descrição." }]), "@param cName, character, Descrição.\n");
 		assert.equal(syntax.getReturn({ paramType: ETypesAdvpl.L, paramDescription: "Funcionou ou não." }), "@return logical, Funcionou ou não.\n");


### PR DESCRIPTION
Adicionando configuração para permitir informar o datelocale que será utilizado na geração do @Since. 

No VSCode, onde o usuário poderia informar as demais configurações da extensão ( como autor default, diretório doc, pasta doc, max files, etc ), caso informe o locale a extenseão considerará o locale informado, caso não informe nada, manterá o comportamento padrão já implementado.